### PR TITLE
Bumping version of referenced creates to latest versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,20 @@ license = "Apache-2.0/MIT"
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-failure = "0.1.5"
-failure_derive = "0.1.5"
+serde = { version = "1.0.123", features = ["derive"] }
+serde_json = "1.0.62"
+failure = "0.1.8"
+failure_derive = "0.1.8"
 lazy_static = "1.4.0"
-common = { path = "common", version = "0.0.1" }
-rcl = { path = "rcl", version = "0.0.1" }
-msg_gen = { path = "msg_gen", version = "0.0.1" }
+common = { path = "common", version = "0.0.2" }
+rcl = { path = "rcl", version = "0.0.2" }
+msg_gen = { path = "msg_gen", version = "0.0.2" }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.62"
 
 [build-dependencies]
-common = { path = "common", version = "0.0.1" }
-msg_gen = { path = "msg_gen", version = "0.0.1" }
+common = { path = "common", version = "0.0.2" }
+msg_gen = { path = "msg_gen", version = "0.0.2" }
 
 [workspace]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "common"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 description = "Minimal ros2 bindings."
 license = "Apache-2.0/MIT"

--- a/msg_gen/Cargo.toml
+++ b/msg_gen/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "msg_gen"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-lazy_static = "1.3.0"
-rcl = { path = "../rcl", version = "0.0.1" }
-common = { path = "../common", version = "0.0.1" }
+lazy_static = "1.4.0"
+rcl = { path = "../rcl", version = "0.0.2" }
+common = { path = "../common", version = "0.0.2" }
 
 [build-dependencies]
-bindgen = "0.52.0"
-rcl = { path = "../rcl", version = "0.0.1" }
-common = { path = "../common", version = "0.0.1" }
-heck = "0.3.1"
+bindgen = "0.57.0"
+rcl = { path = "../rcl", version = "0.0.2" }
+common = { path = "../common", version = "0.0.2" }
+heck = "0.3.2"

--- a/msg_gen/build.rs
+++ b/msg_gen/build.rs
@@ -99,6 +99,7 @@ fn main() {
         .blacklist_type("rosidl_runtime_c__int32__Sequence")
         .blacklist_type("rosidl_runtime_c__uint64__Sequence")
         .blacklist_type("rosidl_runtime_c__int64__Sequence")
+        .size_t_is_usize(true)
         .default_enum_style(bindgen::EnumVariation::Rust {
             non_exhaustive: false,
         });

--- a/rcl/Cargo.toml
+++ b/rcl/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rcl"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Martin Dahl <martin.dahl@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-paste = "0.1.6"
-widestring = "0.4.0"
+paste = "1.0.4"
+widestring = "0.4.3"
 
 [build-dependencies]
-bindgen = "0.52.0"
+bindgen = "0.57.0"

--- a/rcl/build.rs
+++ b/rcl/build.rs
@@ -9,6 +9,7 @@ fn main() {
     let mut builder = bindgen::Builder::default()
         .header("src/rcl_wrapper.h")
         .derive_copy(false)
+        .size_t_is_usize(true)
         .default_enum_style(bindgen::EnumVariation::Rust {
             non_exhaustive: false,
         });


### PR DESCRIPTION
Hi,
First, thanks, for a useful project.

Here is a rather trivial PR that bumps versions of the crates this project depends on to where they are at the moment.

Motivation: I needed to use this create as well as latest `bindgen` 0.57.0 in one of my projects.
It turned out this was was causing a create version conflict.
I though it was a good idea to bring the trunk of `r2r` to where crates it depends on are at the moment.

Tested to work as expected with Rust 1.49 and ROS2 foxy release on Ubuntu 20.04.