### PR TITLE
Fix build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,8 +484,8 @@ impl Context {
     }
 
     pub fn is_valid(&self) -> bool {
-        let ctx = self.context_handle.lock().unwrap();
-        unsafe { rcl_context_is_valid(ctx.as_ref()) }
+        let mut ctx = self.context_handle.lock().unwrap();
+        unsafe { rcl_context_is_valid(&mut ***ctx) }
     }
 }
 


### PR DESCRIPTION
The current HEAD seems to be broken. I don't know that this is the correct fix, but it passes the tests.

The error is below.

```text
error[E0308]: mismatched types
   --> src/lib.rs:488:39
    |
488 |         unsafe { rcl_context_is_valid(ctx.as_ref()) }
    |                                       ^^^^^^^^^^^^ types differ in mutability
    |
    = note: expected raw pointer `*mut rcl::rcl_context_t`
                 found reference `&rcl::rcl_context_t`

error[E0308]: mismatched types
   --> src/lib.rs:488:39
    |
488 |         unsafe { rcl_context_is_valid(ctx.as_ref()) }
    |                                       ^^^^^^^^^^^^ types differ in mutability
    |
    = note: expected raw pointer `*mut rcl::rcl_context_t`
                 found reference `&rcl::rcl_context_t`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `r2r`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: build failed
```