### PR TITLE
Possible lock feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ common = { path = "common", version = "0.1.0" }
 msg_gen = { path = "msg_gen", version = "0.1.0" }
 
 [workspace]
+
+[features]
+lock = ["msg_gen/lock", "rcl/lock"]

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 fn main() {
-    common::print_cargo_watches();
+    // if the lock feature is used, do not rebuild the messages
+    if std::env::var("CARGO_FEATURE_LOCK").is_err() {
+        common::print_cargo_watches();
+    }
 
     let msg_list = if let Some(cmake_includes) = env::var("CMAKE_INCLUDE_DIRS").ok() {
         let packages = cmake_includes

--- a/msg_gen/Cargo.toml
+++ b/msg_gen/Cargo.toml
@@ -14,3 +14,6 @@ bindgen = "0.57.0"
 rcl = { path = "../rcl", version = "0.1.0" }
 common = { path = "../common", version = "0.1.0" }
 heck = "0.3.2"
+
+[features]
+lock = []

--- a/msg_gen/build.rs
+++ b/msg_gen/build.rs
@@ -6,7 +6,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 fn main() {
-    common::print_cargo_watches();
+    // if the lock feature is used, do not rebuild the messages
+    if std::env::var("CARGO_FEATURE_LOCK").is_err() {
+        common::print_cargo_watches();
+    }
 
     let mut builder = bindgen::Builder::default();
 

--- a/rcl/Cargo.toml
+++ b/rcl/Cargo.toml
@@ -12,3 +12,6 @@ widestring = "0.4.3"
 bindgen = "0.57.0"
 itertools = "0.10.0"
 common = { path = "../common", version = "0.1.0" }
+
+[features]
+lock = []

--- a/rcl/build.rs
+++ b/rcl/build.rs
@@ -6,7 +6,10 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 fn main() {
-    common::print_cargo_watches();
+    // if the lock feature is used, do not rebuild the messages
+    if std::env::var("CARGO_FEATURE_LOCK").is_err() {
+        common::print_cargo_watches();
+    }
 
     let mut builder = bindgen::Builder::default()
         .header("src/rcl_wrapper.h")


### PR DESCRIPTION
Added a lock feature to support turning off the rebuild of r2r when the ROS-environment changes. Sometimes useful when developing using the rust-analyzer.

Will need some more testing and evaluation before deciding to merge...