### PR TITLE
Fix colcon build when no actions/msgs/services are present

### DIFF
--- a/r2r_msg_gen/src/lib.rs
+++ b/r2r_msg_gen/src/lib.rs
@@ -518,10 +518,7 @@ impl WrappedNativeMsgUntyped {
     );
     let close = String::from(
         "
-        else
-        {
-            return Err(Error::InvalidMessageType{ msgtype: typename.into() })
-        }
+        return Err(Error::InvalidMessageType{ msgtype: typename.into() })
     }
 }
 ",
@@ -560,10 +557,7 @@ impl UntypedServiceSupport {
     );
     let close = String::from(
         "
-        else
-        {
-            return Err(Error::InvalidMessageType{ msgtype: typename.into() })
-        }
+        return Err(Error::InvalidMessageType{ msgtype: typename.into() })
     }
 }
 ",
@@ -601,10 +595,7 @@ impl UntypedActionSupport {
     );
     let close = String::from(
         "
-        else
-        {
-            return Err(Error::InvalidMessageType{ msgtype: typename.into() })
-        }
+        return Err(Error::InvalidMessageType{ msgtype: typename.into() })
     }
 }
 ",


### PR DESCRIPTION
Description: The auto generated lib r2r_msg_gen assume the presence of at least 1 entry in the messages, actions or services.
If none is present it generates a file with a dangling "else" which generates a compilation error.
Removing the else altogether fixes the issue.

Test:
- cargo test
- cd r2r_msg_gen/ && cargo test
- colcon build on local package with no actions