### PR TITLE
Fix clippy warning in nodes.rs

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -939,7 +939,7 @@ impl Node {
             let topic_types: Vec<String> = unsafe {
                 topic_types
                     .iter()
-                    .map(|t| CStr::from_ptr(*((*t).data)).to_str().unwrap().to_owned())
+                    .map(|t| CStr::from_ptr(*(t.data)).to_str().unwrap().to_owned())
                     .collect()
             };
             res.insert(topic_name, topic_types);


### PR DESCRIPTION
Rust 1.66 (or rather, the clippy bundled with it) adds a new clippy check called `clippy::explicit-auto-deref`. This commit fixes an instance of it in nodes.rs