### PR TITLE
Fixes undeclared type `RCUTILS_LOG_SEVERITY` on foxy.

### DIFF
--- a/r2r_rcl/build.rs
+++ b/r2r_rcl/build.rs
@@ -82,6 +82,7 @@ fn gen_bindings(out_file: &Path) {
         .allowlist_type("rcutils_.*")
         .allowlist_type("rmw_.*")
         .allowlist_type("rosidl_.*")
+        .allowlist_type("RCUTILS_.*")
         .allowlist_var("RCL_.*")
         .allowlist_var("RCUTILS_.*")
         .allowlist_var("RMW_.*")


### PR DESCRIPTION
Fix for #38 