### PR TITLE
Macro for deriving ROS parameters code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "r2r_actions",
     "r2r_common",
     "r2r_msg_gen",
+    "r2r_macros",
     "r2r_rcl",
 ]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ What works?
 - Publish/subscribe
 - Services
 - Actions
-- Rudimentary parameter handling
+- Parameter handling
 
 Changelog
 --------------------

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -31,6 +31,7 @@ phf = "0.11.1"
 serde_json = "1.0.89"
 futures = "0.3.25"
 tokio = { version = "1.22.0", features = ["rt-multi-thread", "macros"] }
+r2r_macros = { path = "../r2r_macros", version = "0.1.0" }
 rand = "0.8.5"
 
 [build-dependencies]

--- a/r2r/examples/parameters_derive.rs
+++ b/r2r/examples/parameters_derive.rs
@@ -1,0 +1,104 @@
+use futures::executor::LocalPool;
+use futures::prelude::*;
+use futures::task::LocalSpawnExt;
+use r2r_macros::RosParams;
+use std::sync::{Arc, Mutex};
+
+// try to run like this
+// cargo run --example parameters_derive -- --ros-args -p par1:=5.1 -p nested.par4:=42 -r __ns:=/demo -r __node:=my_node
+// then run
+// ros2 param get /demo/my_node nested.par4 # should return 42
+// ros2 param set /demo/my_node nested.par4 43
+// ros2 param set /demo/my_node nested.par4 xxx # fails due to invalid type
+// ros2 param set /demo/my_node nested.nested2.par5 999 # fails with conversion error
+// ros2 param dump /demo/my_node
+// Prints:
+//   /demo/my_node:
+//     ros__parameters:
+//       nested:
+//         nested2:
+//           par5: 0
+//         par3: initial value
+//         par4: 43
+//       par1: 5.1
+//       par2: 0
+//
+// Error handling:
+// cargo run --example parameters_derive -- --ros-args -p nested.par4:=xxx
+
+// Explore how is RosParams derived by running:
+// cargo expand --example=parameters_derive
+
+#[derive(RosParams, Default, Debug)]
+struct Params {
+    par1: f64,
+    par2: i32,
+    nested: NestedParams,
+}
+
+#[derive(RosParams, Default, Debug)]
+struct NestedParams {
+    par3: String,
+    par4: u16,
+    nested2: NestedParams2,
+}
+
+#[derive(RosParams, Default, Debug)]
+struct NestedParams2 {
+    par5: i8,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Ros version: {}", r2r::ROS_DISTRO);
+
+    // set up executor
+    let mut pool = LocalPool::new();
+    let spawner = pool.spawner();
+
+    // set up ros node
+    let ctx = r2r::Context::create()?;
+    let mut node = r2r::Node::create(ctx, "to_be_replaced", "to_be_replaced")?;
+
+    // create our parameters and set default values
+    let params = Arc::new(Mutex::new({
+        let mut p = Params::default();
+        p.nested.par3 = "initial value".into();
+        p
+    }));
+
+    // make a parameter handler (once per node).
+    // the parameter handler is optional, only spawn one if you need it.
+    let (paramater_handler, parameter_events) =
+        node.make_derived_parameter_handler(params.clone())?;
+    // run parameter handler on your executor.
+    spawner.spawn_local(paramater_handler)?;
+
+    println!("node name: {}", node.name()?);
+    println!("node fully qualified name: {}", node.fully_qualified_name()?);
+    println!("node namespace: {}", node.namespace()?);
+
+    // parameter event stream. just print them
+    let params_clone = params.clone();
+    spawner.spawn_local(async move {
+        parameter_events
+            .for_each(|_| {
+                println!("event: {:#?}", params_clone.lock().unwrap());
+                future::ready(())
+            })
+            .await
+    })?;
+
+    // print all params every 5 seconds.
+    let mut timer = node.create_wall_timer(std::time::Duration::from_secs(5))?;
+    spawner.spawn_local(async move {
+        loop {
+            println!("timer: {:#?}", params.lock().unwrap());
+            let _elapsed = timer.tick().await.expect("could not tick");
+        }
+    })?;
+
+    loop {
+        node.spin_once(std::time::Duration::from_millis(100));
+        pool.run_until_stalled();
+    }
+}

--- a/r2r/src/error.rs
+++ b/r2r/src/error.rs
@@ -116,6 +116,15 @@ pub enum Error {
 
     #[error("Goal already in a terminal state.")]
     GoalCancelAlreadyTerminated,
+
+    #[error("Invalid parameter name: {name}")]
+    InvalidParameterName { name: String },
+
+    #[error("Invalid type for parameter {name} (should be {ty})")]
+    InvalidParameterType { name: String, ty: &'static str },
+
+    #[error("Parameter {name} conversion failed: {msg}")]
+    ParameterValueConv { name: String, msg: String },
 }
 
 impl Error {
@@ -168,6 +177,24 @@ impl Error {
             }
             _ if e == RCL_RET_ACTION_GOAL_EVENT_INVALID => Error::RCL_RET_ACTION_GOAL_EVENT_INVALID,
             _ => panic!("TODO: add error code {}", e),
+        }
+    }
+
+    /// Internal function used by code derived for the RosParams trait.
+    pub fn update_param_name(self, param_name: &str) -> Error {
+        match self {
+            Error::InvalidParameterName { name: _ } => Error::InvalidParameterName {
+                name: param_name.to_string(),
+            },
+            Error::InvalidParameterType { name: _, ty } => Error::InvalidParameterType {
+                name: param_name.to_string(),
+                ty,
+            },
+            Error::ParameterValueConv { name: _, msg } => Error::ParameterValueConv {
+                name: param_name.to_string(),
+                msg,
+            },
+            _ => self,
         }
     }
 }

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -16,7 +16,7 @@
 //!- Publish/subscribe
 //!- Services
 //!- Actions
-//!- Rudimentary parameter handling
+//!- Parameter handling
 //!
 //! ---
 //!

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -112,7 +112,7 @@ mod context;
 pub use context::Context;
 
 mod parameters;
-pub use parameters::ParameterValue;
+pub use parameters::{ParameterValue, RosParams};
 
 mod clocks;
 pub use clocks::{Clock, ClockType};

--- a/r2r_macros/Cargo.toml
+++ b/r2r_macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "r2r_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.66"
+quote = "1.0.33"
+syn = "2.0.32"

--- a/r2r_macros/src/lib.rs
+++ b/r2r_macros/src/lib.rs
@@ -1,0 +1,121 @@
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+extern crate proc_macro;
+
+// TODO: Should this be called R2RParams? Or R2rParams?
+/// Derives RosParams trait for a structure to use it with
+/// `r2r::Node::make_derived_parameter_handler()`.
+#[proc_macro_derive(RosParams)]
+pub fn derive_r2r_params(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    // Parse the input tokens into a syntax tree.
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // Used in the quasi-quotation below as `#name`.
+    let name = input.ident;
+
+    let register_calls = get_register_calls(&input.data);
+    let get_param_matches = param_matches_for(quote!(get_parameter(suffix)), &input.data);
+    let set_param_matches =
+        param_matches_for(quote!(set_parameter(suffix, param_val)), &input.data);
+
+    let expanded = quote! {
+        // The generated impl.
+        impl ::r2r::RosParams for #name {
+            fn register_parameters(
+                &mut self,
+                prefix: &str,
+                params: &mut ::std::collections::hash_map::HashMap<String, ::r2r::ParameterValue>,
+            ) -> ::r2r::Result<()> {
+                let prefix = if prefix.is_empty() {
+                    String::from("")
+                } else {
+                    format!("{prefix}.")
+                };
+                #register_calls
+                Ok(())
+            }
+            fn get_parameter(&mut self, param_name: &str) -> ::r2r::Result<::r2r::ParameterValue>
+            {
+                let (prefix, suffix) = match param_name.split_once('.') {
+                    None => (param_name, ""),
+                    Some((prefix, suffix)) => (prefix, suffix)
+                };
+                let result = match prefix {
+                    #get_param_matches
+                    _ => Err(::r2r::Error::InvalidParameterName {
+                        name: "".into(),
+                    }),
+                };
+                result.map_err(|e| e.update_param_name(&param_name))
+            }
+            fn set_parameter(&mut self, param_name: &str, param_val: &::r2r::ParameterValue) -> ::r2r::Result<()>
+            {
+                let (prefix, suffix) = match param_name.split_once('.') {
+                    None => (param_name, ""),
+                    Some((prefix, suffix)) => (prefix, suffix)
+                };
+                let result = match prefix {
+                    #set_param_matches
+                    _ => Err(::r2r::Error::InvalidParameterName {
+                        name: "".into(),
+                    }),
+                };
+                result.map_err(|e| e.update_param_name(&param_name))
+            }
+        }
+    };
+
+    // Hand the output tokens back to the compiler.
+    proc_macro::TokenStream::from(expanded)
+}
+
+// Generate calls to register functions of struct fields
+fn get_register_calls(data: &Data) -> TokenStream {
+    match *data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                let field_matches = fields.named.iter().map(|f| {
+                    let name = &f.ident;
+                    let format_str = format!("{{prefix}}{}", name.as_ref().unwrap());
+                    quote_spanned! {
+                        f.span() =>
+                            self.#name.register_parameters(&format!(#format_str), params)?;
+                    }
+                });
+                quote! {
+                    #(#field_matches)*
+                }
+            }
+            _ => unimplemented!(),
+        },
+        Data::Enum(_) | Data::Union(_) => unimplemented!(),
+    }
+}
+
+// Generate match arms for RosParams::update_parameters()
+fn param_matches_for(call: TokenStream, data: &Data) -> TokenStream {
+    match *data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                let field_matches = fields.named.iter().map(|f| {
+                    let name = &f.ident;
+                    let name_str = format!("{}", name.as_ref().unwrap());
+                    quote_spanned! {
+                        f.span() =>
+                            #name_str => {
+                                self.#name.#call
+                            }
+                    }
+                });
+                quote! {
+                    #(#field_matches)*
+                }
+            }
+            _ => unimplemented!(),
+        },
+        Data::Enum(_) | Data::Union(_) => unimplemented!(),
+    }
+}


### PR DESCRIPTION
This is an initial attempt to create a derive macro, which would make dealing with ROS parameters easier. Currently, it works for my simple use case, but it's far from perfect and there is several TODOs and FIXMEs in the code. I'm posting it here if @m-dahl or somebody else wants to comment on it. Please, don't look at individual commits (which are a mess), just the final diff should make sense. I'll clean up the commit history before eventual merge.

How to use this feature is best visible in the `parameters_derive.rs` example.

Before merging this, I think the following should be clarified/fixed:
- [ ] What should be the name of the derived trait? Currently, it's `RosParams`.
- [x] ~Updating of parameters is currently hooked into the event stream. This should probably be changed to happen directly in `set_params_future` handler to report errors to the clients if the parameter was not defined or the value has incorrect type.~
  - [ ] The above may be controllable via [`allow_undeclared_parameters`](https://docs.ros.org/en/rolling/Concepts/Basic/About-Parameters.html#declaring-parameters).
- [x] Error handling/reporting should be completed/extended.
- [x] ~Currently, parameters are "read only". It's possible to change the value of the parameter, but the value is not propagated outside of the node via `rcl_interfaces/srv/GetParameters`~.
- [x] Sane conversion of ParameterValue to underlying type. Currently, we use `as`, which has wrapping semantics, i.e. `255 as i8 == -1`.
- [x] Support String parameters.