### PR TITLE
add windows support

### DIFF
--- a/r2r_msg_gen/build.rs
+++ b/r2r_msg_gen/build.rs
@@ -5,7 +5,7 @@ use itertools::Either;
 use itertools::Itertools;
 use quote::format_ident;
 use quote::quote;
-use r2r_common::{RosMsg, camel_to_snake};
+use r2r_common::{camel_to_snake, RosMsg};
 use rayon::prelude::*;
 use std::fs::File;
 use std::fs::OpenOptions;

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -125,10 +125,18 @@ macro_rules! primitive_sequence {
 primitive_sequence!(rosidl_runtime_c__float32, f32);
 primitive_sequence!(rosidl_runtime_c__float64, f64);
 
-#[cfg(any(all(target_os = "macos", target_arch = "aarch64"), target_arch = "arm"))]
+#[cfg(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    target_arch = "arm",
+    target_os = "windows"
+))]
 primitive_sequence!(rosidl_runtime_c__long_double, f64);
 
-#[cfg(not(any(all(target_os = "macos", target_arch = "aarch64"), target_arch = "arm")))]
+#[cfg(not(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    target_arch = "arm",
+    target_os = "windows"
+)))]
 primitive_sequence!(rosidl_runtime_c__long_double, u128);
 
 primitive_sequence!(rosidl_runtime_c__char, i8);

--- a/r2r_rcl/src/rcl_wrapper.h
+++ b/r2r_rcl/src/rcl_wrapper.h
@@ -1,3 +1,10 @@
+// Workaround for _Check_return_ annotation
+#ifdef _WIN32
+#ifndef _Check_return_
+#define _Check_return_
+#endif
+#endif
+
 // ros client library
 #include <rcl/rcl.h>
 


### PR DESCRIPTION
This PR is to have r2r works under windows, this also enable using cargo-ament for building with colcon

By default once cargo-ament is installed any package containing a package.xml and Cargo.toml is considered as cargo-ament, so using the custom r2r_cargo.cmake does not work anymore