### PR TITLE
Support ROS parameter descriptions

### DIFF
--- a/r2r/examples/parameters.rs
+++ b/r2r/examples/parameters.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         loop {
             println!("node parameters");
             params.lock().unwrap().iter().for_each(|(k, v)| {
-                println!("{} - {:?}", k, v);
+                println!("{} - {:?}", k, v.value);
             });
             let _elapsed = timer.tick().await.expect("could not tick");
         }

--- a/r2r/examples/parameters_derive.rs
+++ b/r2r/examples/parameters_derive.rs
@@ -23,6 +23,17 @@ use std::sync::{Arc, Mutex};
 //       par1: 5.1
 //       par2: 0
 //
+// ros2 param describe /demo/my_node par1 nested.nested2.par5
+// Prints:
+//   Parameter name: par1
+//     Type: double
+//     Description: Parameter description
+//     Constraints:
+//   Parameter name: nested.nested2.par5
+//     Type: integer
+//     Description: Small parameter
+//     Constraints:
+
 // Error handling:
 // cargo run --example parameters_derive -- --ros-args -p nested.par4:=xxx
 
@@ -31,7 +42,9 @@ use std::sync::{Arc, Mutex};
 
 #[derive(RosParams, Default, Debug)]
 struct Params {
+    /// Parameter description
     par1: f64,
+    /// Dummy parameter [m/s]
     par2: i32,
     nested: NestedParams,
 }
@@ -45,6 +58,7 @@ struct NestedParams {
 
 #[derive(RosParams, Default, Debug)]
 struct NestedParams2 {
+    /// Small parameter
     par5: i8,
 }
 

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -112,7 +112,7 @@ mod context;
 pub use context::Context;
 
 mod parameters;
-pub use parameters::{ParameterValue, RosParams};
+pub use parameters::{Parameter, ParameterValue, RosParams};
 
 mod clocks;
 pub use clocks::{Clock, ClockType};

--- a/r2r/src/parameters.rs
+++ b/r2r/src/parameters.rs
@@ -143,6 +143,21 @@ impl ParameterValue {
         }
         ret
     }
+
+    pub(crate) fn into_parameter_type(&self) -> u8 {
+        match self {
+            ParameterValue::NotSet => 0,          // uint8 PARAMETER_NOT_SET=0
+            ParameterValue::Bool(_) => 1,         // uint8 PARAMETER_BOOL=1
+            ParameterValue::Integer(_) => 2,      // uint8 PARAMETER_INTEGER=2
+            ParameterValue::Double(_) => 3,       // uint8 PARAMETER_DOUBLE=3
+            ParameterValue::String(_) => 4,       // uint8 PARAMETER_STRING=4
+            ParameterValue::ByteArray(_) => 5,    // uint8 PARAMETER_BYTE_ARRAY=5
+            ParameterValue::BoolArray(_) => 6,    // uint8 PARAMETER_BOOL_ARRAY=6
+            ParameterValue::IntegerArray(_) => 7, // uint8 PARAMETER_INTEGER_ARRAY=7
+            ParameterValue::DoubleArray(_) => 8,  // uint8 PARAMETER_DOUBLE_ARRAY=8
+            ParameterValue::StringArray(_) => 9,  // int PARAMETER_STRING_ARRAY=9
+        }
+    }
 }
 
 /// Trait for use it with

--- a/r2r_macros/src/lib.rs
+++ b/r2r_macros/src/lib.rs
@@ -5,7 +5,6 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields};
 
 extern crate proc_macro;
 
-// TODO: Should this be called R2RParams? Or R2rParams?
 /// Derives RosParams trait for a structure to use it with
 /// `r2r::Node::make_derived_parameter_handler()`.
 #[proc_macro_derive(RosParams)]


### PR DESCRIPTION
With this change, adding doc comments to fields of structures used with `#[derive(RosParams)]` results in those comments to be used as parameter description.

See `r2r/examples/parameters_derive.rs` for how to use and test this feature.

The advantage of this implementation is that it should be backward compatible with all current users of r2r crate. However, it has also some disadvantages:

- There is no API for setting parameter description without using RosParams trait. Older apps should either be ported to use RosParams or they cannot benefit from this.
- The implementation could be more efficient, if the compatibility is broken. Currently, we have two HashMaps - one for ParameterValues and another for ParameterDescriptors. It might be better to change Node::params to a HashMap whose values contain both ParameterValue and ParameterDescriptior. This way, descriptors would be also available to applications, which might (or might not) be useful.

@m-dahl How stable is r2r API? Would it be acceptable/welcomed to change parameters API as outlined above, say for version 0.8?