### PR TITLE
Support simulated time

### DIFF
--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -49,6 +49,7 @@ prettyplease = "0.2.6"
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen", "r2r_actions/save-bindgen"]
 doc-only = ["r2r_common/doc-only", "r2r_rcl/doc-only", "r2r_msg_gen/doc-only", "r2r_actions/doc-only"]
+sim-time = []
 
 [package.metadata.docs.rs]
 features = ["doc-only"]

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -57,3 +57,7 @@ features = ["doc-only"]
 [[bench]]
 name = "deserialization"
 harness = false
+
+[[example]]
+name = "timer_sim_time"
+required-features = ["sim-time"]

--- a/r2r/Cargo.toml
+++ b/r2r/Cargo.toml
@@ -49,7 +49,6 @@ prettyplease = "0.2.6"
 [features]
 save-bindgen = ["r2r_rcl/save-bindgen", "r2r_msg_gen/save-bindgen", "r2r_actions/save-bindgen"]
 doc-only = ["r2r_common/doc-only", "r2r_rcl/doc-only", "r2r_msg_gen/doc-only", "r2r_actions/doc-only"]
-sim-time = []
 
 [package.metadata.docs.rs]
 features = ["doc-only"]
@@ -57,7 +56,3 @@ features = ["doc-only"]
 [[bench]]
 name = "deserialization"
 harness = false
-
-[[example]]
-name = "timer_sim_time"
-required-features = ["sim-time"]

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -1,0 +1,30 @@
+use r2r::rosgraph_msgs::msg;
+use r2r::ClockType::SystemTime;
+use r2r::{Clock, QosProfile};
+use std::time::Duration;
+
+/// Simple publisher publishing time starting at time 0 every `SENDING_PERIOD`
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = r2r::Context::create()?;
+    let mut node = r2r::Node::create(ctx, "clock_publisher", "")?;
+    let qos = QosProfile::default().keep_last(1);
+    let publisher = node.create_publisher("/clock", qos)?;
+
+    const SENDING_PERIOD: Duration = Duration::from_millis(100);
+    const SIM_TIME_MULTIPLIER: f64 = 0.1;
+
+    let mut clock = Clock::create(SystemTime)?;
+    let zero_time = clock.get_now()?;
+    let mut msg = msg::Clock::default();
+
+    loop {
+        let time_diff = clock.get_now()? - zero_time;
+        let time = time_diff.mul_f64(SIM_TIME_MULTIPLIER);
+        msg.clock = Clock::to_builtin_time(&time);
+
+        publisher.publish(&msg)?;
+        println!("Publishing time {}.{:9} s", time.as_secs(), time.subsec_nanos());
+
+        std::thread::sleep(SENDING_PERIOD);
+    }
+}

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -1,10 +1,11 @@
-use r2r::rosgraph_msgs::msg;
 use r2r::ClockType::SystemTime;
 use r2r::{Clock, QosProfile};
 use std::time::Duration;
 
 /// Simple publisher publishing time starting at time 0 every `SENDING_PERIOD`
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use r2r::rosgraph_msgs::msg;
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "clock_publisher", "")?;
     let qos = QosProfile::default().keep_last(1);
@@ -27,4 +28,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         std::thread::sleep(SENDING_PERIOD);
     }
+}
+
+#[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
+fn main() {
 }

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -32,4 +32,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
 fn main() {
+    panic!("Sim_time_publisher example is not compiled with 'rosgraph_msgs'.");
 }

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -1,0 +1,82 @@
+use futures::executor::LocalPool;
+use futures::task::LocalSpawnExt;
+
+use r2r::{Clock, ClockType};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+async fn timer_task(
+    mut t: r2r::Timer, ros_clock: Arc<Mutex<Clock>>, mut system_clock: Clock,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut iteration: i32 = 0;
+    loop {
+        let elapsed = t.tick().await?;
+
+        let ros_time = ros_clock.lock().unwrap().get_now()?;
+        let system_time = system_clock.get_now()?;
+
+        println!("Timer called ({}), {}us since last call", iteration, elapsed.as_micros());
+        println!(
+            "\tcurrent time ros={:.3}s, system={:.3}s",
+            ros_time.as_secs_f64(),
+            system_time.as_secs_f64()
+        );
+
+        iteration += 1;
+        if iteration == 10 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Publication of time can be done either using the example `sim_time_publisher`
+/// or with `ros2 bag play --clock <clock_frequency> <the_bag>`
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = r2r::Context::create()?;
+    let mut node = r2r::Node::create(ctx, "testnode", "")?;
+
+    let mut pool = LocalPool::new();
+    let spawner = pool.spawner();
+
+    // Simulated time can be enabled by registering parameter handler
+    // and starting the program this ros param 'use_sim_time:=true'
+    // ```shell
+    // cargo run --features=sim-time --example=timer_sim_time -- --ros-args -p use_sim_time:=true
+    // ```
+    // this does not work if the parameter is changed during the runtime
+    let (paramater_handler, _parameter_events) = node.make_parameter_handler()?;
+    spawner.spawn_local(paramater_handler)?;
+
+    // or simulated time can be enabled/disabled directly by calling these functions:
+    // let time_source = node.get_time_source();
+    // time_source.enable_sim_time(&mut node)?;
+    // time_source.disable_sim_time();
+
+    // Note: Wall timer does not use sim time
+    let timer = node.create_timer(std::time::Duration::from_millis(1000))?;
+
+    let is_done = Rc::new(RefCell::new(false));
+
+    let task_is_done = is_done.clone();
+    let ros_clock = node.get_ros_clock();
+    let system_clock = Clock::create(ClockType::SystemTime)?;
+    spawner.spawn_local(async move {
+        match timer_task(timer, ros_clock, system_clock).await {
+            Ok(()) => {
+                *task_is_done.borrow_mut() = true;
+                println!("exiting");
+            }
+            Err(e) => println!("error: {}", e),
+        }
+    })?;
+
+    while !*is_done.borrow() {
+        node.spin_once(std::time::Duration::from_millis(100));
+
+        pool.run_until_stalled();
+    }
+
+    Ok(())
+}

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -33,6 +33,7 @@ async fn timer_task(
 
 /// Publication of time can be done either using the example `sim_time_publisher`
 /// or with `ros2 bag play --clock <clock_frequency> <the_bag>`
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;
@@ -79,4 +80,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
+fn main() {
+    panic!("Timer_sim_time example is not compiled with 'rosgraph_msgs'.");
 }

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Simulated time can be enabled by registering parameter handler
     // and starting the program this ros param 'use_sim_time:=true'
     // ```shell
-    // cargo run --features=sim-time --example=timer_sim_time -- --ros-args -p use_sim_time:=true
+    // cargo run --example=timer_sim_time -- --ros-args -p use_sim_time:=true
     // ```
     // this does not work if the parameter is changed during the runtime
     let (paramater_handler, _parameter_events) = node.make_parameter_handler()?;

--- a/r2r/src/clocks.rs
+++ b/r2r/src/clocks.rs
@@ -85,7 +85,7 @@ impl Clock {
     /// The clock must be [`ClockType::RosTime`].
     ///
     /// Wrapper for `rcl_enable_ros_time_override`
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub(crate) fn enable_ros_time_override(
         &mut self, initial_time: rcl_time_point_value_t,
     ) -> Result<()> {
@@ -110,7 +110,7 @@ impl Clock {
     /// The clock must be [`ClockType::RosTime`].
     ///
     /// Wrapper for `rcl_disable_ros_time_override`
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub(crate) fn disable_ros_time_override(&mut self) -> Result<()> {
         let valid = unsafe { rcl_clock_valid(&mut *self.clock_handle) };
         if !valid {
@@ -133,7 +133,7 @@ impl Clock {
     /// The clock must be [`ClockType::RosTime`].
     ///
     /// Wrapper for `rcl_set_ros_time_override`
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub(crate) fn set_ros_time_override(&mut self, time: rcl_time_point_value_t) -> Result<()> {
         let valid = unsafe { rcl_clock_valid(&mut *self.clock_handle) };
         if !valid {

--- a/r2r/src/error.rs
+++ b/r2r/src/error.rs
@@ -83,6 +83,8 @@ pub enum Error {
     RCL_RET_EVENT_TAKE_FAILED,
 
     // Our own errors
+    #[error("Clock type is not RosTime")]
+    ClockTypeNotRosTime,
     #[error("No typesupport built for the message type: {}", msgtype)]
     InvalidMessageType { msgtype: String },
     #[error("Serde error: {}", err)]

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -124,6 +124,12 @@ mod nodes;
 pub use nodes::{Node, Timer};
 
 pub mod qos;
+
+#[cfg(feature = "sim-time")]
+mod time_source;
+#[cfg(feature = "sim-time")]
+pub use time_source::TimeSource;
+
 pub use qos::QosProfile;
 
 /// The ros version currently built against.

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -125,9 +125,9 @@ pub use nodes::{Node, Timer};
 
 pub mod qos;
 
-#[cfg(feature = "sim-time")]
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 mod time_source;
-#[cfg(feature = "sim-time")]
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 pub use time_source::TimeSource;
 
 pub use qos::QosProfile;

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -39,9 +39,9 @@ pub struct Node {
     context: Context,
     /// ROS parameters.
     pub params: Arc<Mutex<HashMap<String, Parameter>>>,
-    node_handle: Box<rcl_node_t>,
+    pub(crate) node_handle: Box<rcl_node_t>,
     // the node owns the subscribers
-    subscribers: Vec<Box<dyn Subscriber_>>,
+    pub(crate) subscribers: Vec<Box<dyn Subscriber_>>,
     // services,
     services: Vec<Arc<Mutex<dyn Service_>>>,
     // service clients

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1333,6 +1333,21 @@ impl Node {
         let s = unsafe { CStr::from_ptr(ptr) };
         s.to_str().unwrap_or("")
     }
+
+    /// Get TimeSource of the node
+    ///
+    /// See: [`TimeSource`]
+    #[cfg(feature = "sim-time")]
+    pub fn get_time_source(&self) -> TimeSource {
+        self.time_source.clone()
+    }
+
+    /// Get ROS clock of the node
+    ///
+    /// This is the same clock that is used by ROS timers created in [`Node::create_timer`].
+    pub fn get_ros_clock(&self) -> Arc<Mutex<Clock>> {
+        self.ros_clock.clone()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -29,7 +29,7 @@ use crate::publishers::*;
 use crate::qos::QosProfile;
 use crate::services::*;
 use crate::subscribers::*;
-#[cfg(feature = "sim-time")]
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
 use crate::time_source::TimeSource;
 
 /// A ROS Node.
@@ -59,7 +59,7 @@ pub struct Node {
     // RosTime clock used by all timers created by create_timer()
     ros_clock: Arc<Mutex<Clock>>,
     // time source that provides simulated time
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     time_source: TimeSource,
 }
 
@@ -187,7 +187,7 @@ impl Node {
 
         if res == RCL_RET_OK as i32 {
             let ros_clock = Arc::new(Mutex::new(Clock::create(ClockType::RosTime)?));
-            #[cfg(feature = "sim-time")]
+            #[cfg(r2r__rosgraph_msgs__msg__Clock)]
             let time_source = {
                 let time_source = TimeSource::new();
                 time_source.attach_ros_clock(Arc::downgrade(&ros_clock))?;
@@ -206,7 +206,7 @@ impl Node {
                 timers: Vec::new(),
                 pubs: Vec::new(),
                 ros_clock,
-                #[cfg(feature = "sim-time")]
+                #[cfg(r2r__rosgraph_msgs__msg__Clock)]
                 time_source,
             };
             node.load_params()?;
@@ -428,7 +428,7 @@ impl Node {
 
         handlers.push(Box::pin(get_param_types_future));
 
-        #[cfg(feature = "sim-time")]
+        #[cfg(r2r__rosgraph_msgs__msg__Clock)]
         {
             // create TimeSource based on value of use_sim_time parameter
             let use_sim_time = {
@@ -1337,7 +1337,7 @@ impl Node {
     /// Get TimeSource of the node
     ///
     /// See: [`TimeSource`]
-    #[cfg(feature = "sim-time")]
+    #[cfg(r2r__rosgraph_msgs__msg__Clock)]
     pub fn get_time_source(&self) -> TimeSource {
         self.time_source.clone()
     }

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1241,7 +1241,7 @@ impl Node {
 
         let timer = Timer_ {
             timer_handle,
-            _clock: clock,
+            _clock: Some(clock),
             sender: tx,
         };
         self.timers.push(timer);
@@ -1279,7 +1279,7 @@ impl RclTimer {
 
 struct Timer_ {
     timer_handle: Pin<Box<RclTimer>>,
-    _clock: Clock, // just here to be dropped properly later.
+    _clock: Option<Clock>, // Some(clock) if the timer owns the clock, just here to be dropped properly later.
     sender: mpsc::Sender<Duration>,
 }
 

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "sim-time")]
+#![cfg(r2r__rosgraph_msgs__msg__Clock)]
 
 use crate::builtin_interfaces::msg::Time;
 use crate::error::*;

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -1,0 +1,251 @@
+#![cfg(feature = "sim-time")]
+
+use crate::builtin_interfaces::msg::Time;
+use crate::error::*;
+use crate::msg_types::{VoidPtr, WrappedNativeMsg};
+use crate::rosgraph_msgs;
+use crate::subscribers::{create_subscription_helper, Subscriber_};
+use crate::{Clock, ClockType, Node, QosProfile, WrappedTypesupport};
+use r2r_rcl::{
+    rcl_node_t, rcl_subscription_fini, rcl_subscription_t, rcl_take, rcl_time_point_value_t,
+    rmw_message_info_t, RCL_RET_OK,
+};
+use std::sync::{Arc, Mutex, Weak};
+
+/// Provides time from `/clock` topic to attached ROS clocks
+///
+/// By default only clock used by ROS timers is attached and time from `/clock` topic is disabled.
+///
+/// The time from `/clock` topic can be activated by either of these:
+/// - calling [`TimeSource::enable_sim_time`]
+/// - having registered parameter handler and launching the node with parameter `use_sim_time:=true`
+///
+/// Similar to `rclcpp/time_source.hpp`
+#[derive(Clone)]
+pub struct TimeSource {
+    inner: Arc<Mutex<TimeSource_>>,
+}
+
+pub(crate) struct TimeSource_ {
+    managed_clocks: Vec<Weak<Mutex<Clock>>>,
+    subscriber_state: TimeSourceSubscriberState,
+    simulated_time_enabled: bool,
+    last_time_msg: rcl_time_point_value_t,
+}
+
+#[derive(Copy, Clone)]
+enum TimeSourceSubscriberState {
+    None, // subscriber does not exist
+    Active,
+    ToBeDestroyed,
+}
+
+struct TimeSourceSubscriber {
+    subscriber_handle: rcl_subscription_t,
+    time_source: TimeSource,
+}
+
+impl TimeSource {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TimeSource_::new())),
+        }
+    }
+
+    /// Attach clock of type [`RosTime`](ClockType::RosTime) to the [`TimeSource`]
+    ///
+    /// If the simulated time is enabled the [`TimeSource`] will distribute simulated time
+    /// to all attached clocks.
+    pub fn attach_ros_clock(&self, clock: Weak<Mutex<Clock>>) -> Result<()> {
+        let mut time_source = self.inner.lock().unwrap();
+        let clock_valid = clock
+            .upgrade()
+            .map(|clock_arc| {
+                let mut clock = clock_arc.lock().unwrap();
+
+                if !matches!(clock.get_clock_type(), ClockType::RosTime) {
+                    return Err(Error::ClockTypeNotRosTime);
+                }
+
+                if time_source.simulated_time_enabled {
+                    clock.enable_ros_time_override(time_source.last_time_msg)?;
+                }
+
+                Ok(())
+            })
+            .transpose()?
+            .is_some();
+        if clock_valid {
+            time_source.managed_clocks.push(clock);
+        }
+        // if upgrade is none no need to attach the clock since it is already dropped
+
+        Ok(())
+    }
+
+    /// Enables usage of simulated time
+    ///
+    /// Simulated time is provided on topic `"/clock"` in the message [rosgraph_msgs::msg::Clock].
+    pub fn enable_sim_time(&self, node: &mut Node) -> Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.simulated_time_enabled {
+            // already enabled nothing to do
+            return Ok(());
+        }
+
+        inner.simulated_time_enabled = true;
+
+        match inner.subscriber_state {
+            TimeSourceSubscriberState::None => {
+                let subscriber = TimeSourceSubscriber::new(&mut node.node_handle, self.clone())?;
+                node.subscribers.push(Box::new(subscriber));
+                inner.subscriber_state = TimeSourceSubscriberState::Active;
+            }
+            TimeSourceSubscriberState::ToBeDestroyed => {
+                inner.subscriber_state = TimeSourceSubscriberState::Active;
+            }
+            TimeSourceSubscriberState::Active => {
+                // nothing to do
+            }
+        }
+
+        let initial_time = inner.last_time_msg;
+        // enable ros time override on all attached clocks
+        inner.for_each_managed_clock(|clock| {
+            // This should never panic:
+            // This could only fail if the clock is invalid or not RosTime, but the clock is
+            // attached only if it is valid clock with type RosTime.
+            clock.enable_ros_time_override(initial_time).unwrap();
+        });
+
+        Ok(())
+    }
+
+    /// Disables usage of simulated time
+    ///
+    /// This will schedule removal of internal subscriber to the `"/clock"` topic on the next
+    /// receipt of [`rosgraph_msgs::msg::Clock`] message.
+    pub fn disable_sim_time(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.simulated_time_enabled {
+            inner.simulated_time_enabled = false;
+
+            // disable ros time override on all attached clocks
+            inner.for_each_managed_clock(|clock| {
+                // This should never panic:
+                // This could only fail if the clock is invalid or not RosTime, but the clock is
+                // attached only if it is valid clock with type RosTime.
+                clock.disable_ros_time_override().unwrap();
+            });
+        }
+
+        if matches!(inner.subscriber_state, TimeSourceSubscriberState::Active) {
+            inner.subscriber_state = TimeSourceSubscriberState::ToBeDestroyed;
+        }
+    }
+}
+
+impl TimeSource_ {
+    fn new() -> Self {
+        Self {
+            managed_clocks: vec![],
+            subscriber_state: TimeSourceSubscriberState::None,
+            simulated_time_enabled: false,
+            last_time_msg: 0,
+        }
+    }
+
+    fn for_each_managed_clock<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Clock),
+    {
+        self.managed_clocks.retain(|weak_clock| {
+            let Some(clock_arc) = weak_clock.upgrade() else {
+                // clock can be deleted
+                return false;
+            };
+
+            let mut clock = clock_arc.lock().unwrap();
+            f(&mut clock);
+
+            // retain clock
+            true
+        });
+    }
+
+    // this is similar to internal rclcpp function `set_all_clocks` in `time_source.cpp`
+    fn set_clock_time(&mut self, time_msg: Time) {
+        let time = time_msg.into();
+        self.last_time_msg = time;
+        self.for_each_managed_clock(|clock| {
+            // This should never panic:
+            // This could only fail if the clock is invalid or not RosTime, but the clock is
+            // attached only if it is valid RosTime clock.
+            clock.set_ros_time_override(time).unwrap()
+        });
+    }
+}
+
+impl TimeSourceSubscriber {
+    fn new(node_handle: &mut rcl_node_t, time_source: TimeSource) -> Result<TimeSourceSubscriber> {
+        // The values are set based on default values in rclcpp
+        let qos = QosProfile::default().keep_last(1).best_effort();
+
+        let subscriber = create_subscription_helper(
+            node_handle,
+            "/clock",
+            crate::rosgraph_msgs::msg::Clock::get_ts(),
+            qos,
+        )?;
+        Ok(Self {
+            subscriber_handle: subscriber,
+            time_source,
+        })
+    }
+}
+
+impl Subscriber_ for TimeSourceSubscriber {
+    fn handle(&self) -> &rcl_subscription_t {
+        &self.subscriber_handle
+    }
+
+    fn handle_incoming(&mut self) -> bool {
+        // update clock
+        let mut msg_info = rmw_message_info_t::default(); // we dont care for now
+        let mut clock_msg = WrappedNativeMsg::<rosgraph_msgs::msg::Clock>::new();
+        let ret = unsafe {
+            rcl_take(
+                &self.subscriber_handle,
+                clock_msg.void_ptr_mut(),
+                &mut msg_info,
+                std::ptr::null_mut(),
+            )
+        };
+
+        let mut inner_time_source = self.time_source.inner.lock().unwrap();
+        if ret == RCL_RET_OK as i32 {
+            let msg = rosgraph_msgs::msg::Clock::from_native(&clock_msg);
+
+            inner_time_source.set_clock_time(msg.clock);
+        }
+
+        match inner_time_source.subscriber_state {
+            TimeSourceSubscriberState::Active => {
+                // keep the subscriber
+                false
+            }
+            TimeSourceSubscriberState::ToBeDestroyed => {
+                inner_time_source.subscriber_state = TimeSourceSubscriberState::None;
+                // destroy the subscriber
+                true
+            }
+            TimeSourceSubscriberState::None => unreachable!(),
+        }
+    }
+
+    fn destroy(&mut self, node: &mut rcl_node_t) {
+        unsafe {
+            rcl_subscription_fini(&mut self.subscriber_handle, node);
+        }
+    }
+}

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -86,6 +86,8 @@ impl TimeSource {
     /// Enables usage of simulated time
     ///
     /// Simulated time is provided on topic `"/clock"` in the message [rosgraph_msgs::msg::Clock].
+    ///
+    /// See example: sim_time_publisher.rs
     pub fn enable_sim_time(&self, node: &mut Node) -> Result<()> {
         let mut inner = self.inner.lock().unwrap();
         if inner.simulated_time_enabled {

--- a/r2r/src/utils.rs
+++ b/r2r/src/utils.rs
@@ -139,6 +139,22 @@ macro_rules! log_fatal {
     }}
 }
 
+/// Causes compile time error if `use_sim_time` is unsupported.
+#[cfg(r2r__rosgraph_msgs__msg__Clock)]
+#[macro_export]
+macro_rules! assert_compiled_with_use_sim_time_support {
+    () => {};
+}
+
+/// Causes compile time error if `use_sim_time` is unsupported.
+#[cfg(not(r2r__rosgraph_msgs__msg__Clock))]
+#[macro_export]
+macro_rules! assert_compiled_with_use_sim_time_support {
+    () => {
+        compile_error!("assert_compiled_with_use_sim_time_support failed: 'rosgraph_msgs' dependency is missing!");
+    };
+}
+
 #[test]
 fn test_log() {
     log_debug!("log_test", "debug msg");


### PR DESCRIPTION
# Motivation

The simulated time feature (enabled with the `use_sim_time` parameter) is useful when the node is run in a simulated environment, e.g., with `ros2 bag`. It allows the simulator to run slower or faster than in real time.

# Implementation Notes

This implementation is based on the existing implementation in rclcpp.

- Each node has its own `RosTime` clock that is used to create timers.
- Time source is responsible for subscribing to the `/clock` topic and updating attached clocks.
- The callback of `TimeSourceSubscriber` does not use async runtime. It is run in the `handle_incoming()` method during node spinning.
- The destruction of `TimeSourceSubscriber` is done after disabling the simulated time when the next time message is received.

## rclcpp class diagram

rclcpp implements this feature with the help of several classes which are related as shown in the following diagram. In the simplest (default) case, each node has a NodeClock, which is referenced from both the Node and its TimeSource. If one wants, other clocks can be added to the TimeSource via the attachClock() method.

![clock-class-diagram](https://github.com/skoudmar/r2r/assets/36601455/14cdc4b4-c75f-4679-b6f3-22e09fe22fa7)

## r2r class diagram

For r2r we decided to implement this in a simpler way, as shown in the following diagram. A `TimeSource` can drive one or more clocks as in rclcpp. The difference is that the `TimeSourceSubscriber` is stored in Node alongside other subscribers instead of in `TimeSource` as in rclcpp.

![r2r-timesource-classdiagram](https://github.com/skoudmar/r2r/assets/36601455/5d877cab-371a-4fae-939e-a8b074190ed4)


## Enabling simulated time

Simulated time can be enabled in two ways:

1. In the rust code,
```rust
node.get_time_source().enable_sim_time(&mut node)?;
```

2. Optionally, by setting `use_sime_time` parameter at node initialization time if the node uses a derived parameter handler.
  - It is enabled during the registration of the derived parameter handler.
  - The simulated time cannot be enabled later because it would require storing a `&mut node` in a parameter change callback.

## Feature gate

This functionality uses cargo features because the message on the `/clock` topic has the type Clock defined in [rosgraph_msgs](https://index.ros.org/p/rosgraph_msgs/), and if the user does not declare it as a dependency, the compilation will fail. This would break existing projects.

# Final notes

We already use this feature with @wentasah and have not encountered any problems.

We suggest to review this commit-by-commit.
