### PR TITLE
New rustfmt.toml

### DIFF
--- a/r2r/benches/deserialization.rs
+++ b/r2r/benches/deserialization.rs
@@ -1,7 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use r2r::*;
-use rand::thread_rng;
-use rand::Rng;
+use rand::{thread_rng, Rng};
 
 const NUM_ELEMENTS: usize = 10_000;
 const NUM_TIMES: usize = 1_000;

--- a/r2r/build.rs
+++ b/r2r/build.rs
@@ -7,8 +7,10 @@ use {
     std::io::{self, prelude::*, BufWriter},
 };
 
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 #[cfg(feature = "doc-only")]
 mod filenames {

--- a/r2r/examples/action_client.rs
+++ b/r2r/examples/action_client.rs
@@ -1,7 +1,4 @@
-use futures::executor::LocalPool;
-use futures::future::FutureExt;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future::FutureExt, stream::StreamExt, task::LocalSpawnExt};
 
 use r2r::example_interfaces::action::Fibonacci;
 use std::sync::{Arc, Mutex};

--- a/r2r/examples/action_client_untyped.rs
+++ b/r2r/examples/action_client_untyped.rs
@@ -1,10 +1,7 @@
 //
 // This example is the same as action_client.rs but stripped of all (explicit) type information.
 //
-use futures::executor::LocalPool;
-use futures::future::FutureExt;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future::FutureExt, stream::StreamExt, task::LocalSpawnExt};
 
 use std::sync::{Arc, Mutex};
 

--- a/r2r/examples/action_server.rs
+++ b/r2r/examples/action_server.rs
@@ -1,7 +1,9 @@
-use futures::executor::{LocalPool, LocalSpawner};
-use futures::future::{self, Either};
-use futures::stream::{Stream, StreamExt};
-use futures::task::LocalSpawnExt;
+use futures::{
+    executor::{LocalPool, LocalSpawner},
+    future::{self, Either},
+    stream::{Stream, StreamExt},
+    task::LocalSpawnExt,
+};
 
 use r2r::example_interfaces::action::Fibonacci;
 use std::sync::{Arc, Mutex};

--- a/r2r/examples/client.rs
+++ b/r2r/examples/client.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
-use futures::Future;
+use futures::{executor::LocalPool, task::LocalSpawnExt, Future};
 
 use std::io::Write;
 

--- a/r2r/examples/parameters.rs
+++ b/r2r/examples/parameters.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::prelude::*;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, prelude::*, task::LocalSpawnExt};
 
 // try to run like this
 // cargo run --example parameters -- --ros-args -p key1:=[hello,world] -p key2:=5.5 -r __ns:=/demo -r __node:=my_node

--- a/r2r/examples/parameters_derive.rs
+++ b/r2r/examples/parameters_derive.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::prelude::*;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, prelude::*, task::LocalSpawnExt};
 use r2r::RosParams;
 use std::sync::{Arc, Mutex};
 

--- a/r2r/examples/publishers.rs
+++ b/r2r/examples/publishers.rs
@@ -1,7 +1,6 @@
-use r2r::builtin_interfaces::msg::Duration;
-use r2r::std_msgs::msg::Int32;
-use r2r::trajectory_msgs::msg::*;
-use r2r::QosProfile;
+use r2r::{
+    builtin_interfaces::msg::Duration, std_msgs::msg::Int32, trajectory_msgs::msg::*, QosProfile,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;

--- a/r2r/examples/rostopic_echo.rs
+++ b/r2r/examples/rostopic_echo.rs
@@ -1,12 +1,7 @@
-use futures::executor::LocalPool;
-use futures::future;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future, stream::StreamExt, task::LocalSpawnExt};
 use r2r::QosProfile;
 
-use std::collections::HashMap;
-use std::env;
-use std::thread;
+use std::{collections::HashMap, env, thread};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;

--- a/r2r/examples/rostopic_list.rs
+++ b/r2r/examples/rostopic_list.rs
@@ -1,5 +1,4 @@
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;

--- a/r2r/examples/service.rs
+++ b/r2r/examples/service.rs
@@ -1,8 +1,4 @@
-use futures::executor::LocalPool;
-use futures::select;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
-use futures::FutureExt;
+use futures::{executor::LocalPool, select, stream::StreamExt, task::LocalSpawnExt, FutureExt};
 
 use r2r::example_interfaces::srv::AddTwoInts;
 
@@ -12,7 +8,6 @@ use r2r::example_interfaces::srv::AddTwoInts;
 /// Run toghtether with the client example.
 /// e.g. cargo run --example service
 /// and in another terminal cargo run --example client
-///
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = r2r::Context::create()?;
     let mut node = r2r::Node::create(ctx, "testnode", "")?;

--- a/r2r/examples/sim_time_publisher.rs
+++ b/r2r/examples/sim_time_publisher.rs
@@ -1,5 +1,4 @@
-use r2r::ClockType::SystemTime;
-use r2r::{Clock, QosProfile};
+use r2r::{Clock, ClockType::SystemTime, QosProfile};
 use std::time::Duration;
 
 /// Simple publisher publishing time starting at time 0 every `SENDING_PERIOD`

--- a/r2r/examples/subscriber.rs
+++ b/r2r/examples/subscriber.rs
@@ -1,7 +1,4 @@
-use futures::executor::LocalPool;
-use futures::future;
-use futures::stream::StreamExt;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, future, stream::StreamExt, task::LocalSpawnExt};
 use r2r::QosProfile;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/r2r/examples/timer_sim_time.rs
+++ b/r2r/examples/timer_sim_time.rs
@@ -1,10 +1,11 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, task::LocalSpawnExt};
 
 use r2r::{Clock, ClockType};
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 
 async fn timer_task(
     mut t: r2r::Timer, ros_clock: Arc<Mutex<Clock>>, mut system_clock: Clock,

--- a/r2r/examples/tokio.rs
+++ b/r2r/examples/tokio.rs
@@ -1,5 +1,4 @@
-use futures::future;
-use futures::stream::StreamExt;
+use futures::{future, stream::StreamExt};
 use r2r::QosProfile;
 
 use std::sync::{Arc, Mutex};

--- a/r2r/examples/tokio_examples.rs
+++ b/r2r/examples/tokio_examples.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use futures::future;
-use futures::stream::StreamExt;
+use futures::{future, stream::StreamExt};
 
 use r2r::QosProfile;
 use tokio::task;

--- a/r2r/examples/tokio_raw_publisher.rs
+++ b/r2r/examples/tokio_raw_publisher.rs
@@ -1,5 +1,4 @@
-use r2r::QosProfile;
-use r2r::WrappedTypesupport;
+use r2r::{QosProfile, WrappedTypesupport};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/r2r/examples/tokio_raw_subscriber.rs
+++ b/r2r/examples/tokio_raw_subscriber.rs
@@ -1,7 +1,5 @@
-use futures::future;
-use futures::stream::StreamExt;
-use r2r::QosProfile;
-use r2r::WrappedTypesupport;
+use futures::{future, stream::StreamExt};
+use r2r::{QosProfile, WrappedTypesupport};
 use serde::{Deserialize, Serialize};
 
 #[tokio::main]

--- a/r2r/examples/tokio_subscriber.rs
+++ b/r2r/examples/tokio_subscriber.rs
@@ -1,5 +1,4 @@
-use futures::future;
-use futures::stream::StreamExt;
+use futures::{future, stream::StreamExt};
 use r2r::QosProfile;
 
 #[tokio::main]

--- a/r2r/examples/untyped_client.rs
+++ b/r2r/examples/untyped_client.rs
@@ -1,6 +1,4 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
-use futures::Future;
+use futures::{executor::LocalPool, task::LocalSpawnExt, Future};
 
 async fn requester_task(
     node_available: impl Future<Output = r2r::Result<()>>, c: r2r::ClientUntyped,

--- a/r2r/examples/wall_timer.rs
+++ b/r2r/examples/wall_timer.rs
@@ -1,8 +1,6 @@
-use futures::executor::LocalPool;
-use futures::task::LocalSpawnExt;
+use futures::{executor::LocalPool, task::LocalSpawnExt};
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 async fn timer_task(mut t: r2r::Timer) -> Result<(), Box<dyn std::error::Error>> {
     let mut x: i32 = 0;

--- a/r2r/src/action_clients.rs
+++ b/r2r/src/action_clients.rs
@@ -1,16 +1,24 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::{FutureExt, TryFutureExt};
-use futures::stream::Stream;
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::future::Future;
-use std::mem::MaybeUninit;
-use std::sync::{Mutex, Weak};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{FutureExt, TryFutureExt},
+    stream::Stream,
+};
+use std::{
+    collections::HashMap,
+    ffi::CString,
+    future::Future,
+    mem::MaybeUninit,
+    sync::{Mutex, Weak},
+};
 
-use crate::action_common::*;
-use crate::error::*;
-use crate::msg_types::generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs};
-use crate::msg_types::*;
+use crate::{
+    action_common::*,
+    error::*,
+    msg_types::{
+        generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs},
+        *,
+    },
+};
 use r2r_actions::*;
 use r2r_rcl::*;
 

--- a/r2r/src/action_clients_untyped.rs
+++ b/r2r/src/action_clients_untyped.rs
@@ -1,16 +1,24 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::{FutureExt, TryFutureExt};
-use futures::stream::Stream;
-use std::collections::HashMap;
-use std::future::Future;
-use std::mem::MaybeUninit;
-use std::sync::{Mutex, Weak};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{FutureExt, TryFutureExt},
+    stream::Stream,
+};
+use std::{
+    collections::HashMap,
+    future::Future,
+    mem::MaybeUninit,
+    sync::{Mutex, Weak},
+};
 
-use crate::action_clients::*;
-use crate::action_common::*;
-use crate::error::*;
-use crate::msg_types::generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs};
-use crate::msg_types::*;
+use crate::{
+    action_clients::*,
+    action_common::*,
+    error::*,
+    msg_types::{
+        generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs},
+        *,
+    },
+};
 use r2r_actions::*;
 use r2r_rcl::*;
 //

--- a/r2r/src/action_servers.rs
+++ b/r2r/src/action_servers.rs
@@ -1,15 +1,22 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::FutureExt;
-use futures::future::{join_all, JoinAll};
-use futures::stream::Stream;
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::mem::MaybeUninit;
-use std::sync::{Arc, Mutex, Weak};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{join_all, FutureExt, JoinAll},
+    stream::Stream,
+};
+use std::{
+    collections::HashMap,
+    ffi::CString,
+    mem::MaybeUninit,
+    sync::{Arc, Mutex, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs};
-use crate::msg_types::*;
+use crate::{
+    error::*,
+    msg_types::{
+        generated_msgs::{action_msgs, builtin_interfaces, unique_identifier_msgs},
+        *,
+    },
+};
 use r2r_actions::*;
 use r2r_rcl::*;
 

--- a/r2r/src/clients.rs
+++ b/r2r/src/clients.rs
@@ -1,12 +1,12 @@
-use futures::channel::oneshot;
-use futures::TryFutureExt;
-use std::ffi::CString;
-use std::future::Future;
-use std::mem::MaybeUninit;
-use std::sync::{Mutex, Weak};
+use futures::{channel::oneshot, TryFutureExt};
+use std::{
+    ffi::CString,
+    future::Future,
+    mem::MaybeUninit,
+    sync::{Mutex, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::*;
+use crate::{error::*, msg_types::*};
 use r2r_rcl::*;
 
 /// ROS service client.

--- a/r2r/src/clocks.rs
+++ b/r2r/src/clocks.rs
@@ -1,9 +1,6 @@
-use std::fmt::Debug;
-use std::mem::MaybeUninit;
-use std::time::Duration;
+use std::{fmt::Debug, mem::MaybeUninit, time::Duration};
 
-use crate::error::*;
-use crate::msg_types::generated_msgs::builtin_interfaces;
+use crate::{error::*, msg_types::generated_msgs::builtin_interfaces};
 use r2r_rcl::*;
 
 /// Different ROS clock types.

--- a/r2r/src/context.rs
+++ b/r2r/src/context.rs
@@ -1,12 +1,11 @@
-use std::ffi::CStr;
-use std::ffi::CString;
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
-use std::sync::OnceLock;
-use std::sync::{Arc, Mutex};
+use std::{
+    ffi::{CStr, CString},
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex, OnceLock},
+};
 
-use crate::error::*;
-use crate::log_guard;
+use crate::{error::*, log_guard};
 use r2r_rcl::*;
 
 /// A ROS context. Needed to create nodes etc.

--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -24,48 +24,51 @@
 //! try the following example:
 //!
 //! ``` rust
-//!use futures::executor::LocalPool;
-//!use futures::future;
-//!use futures::stream::StreamExt;
-//!use futures::task::LocalSpawnExt;
-//!use r2r::QosProfile;
+//! use futures::{executor::LocalPool, future, stream::StreamExt, task::LocalSpawnExt};
+//! use r2r::QosProfile;
 //!
-//!fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!    let ctx = r2r::Context::create()?;
-//!    let mut node = r2r::Node::create(ctx, "node", "namespace")?;
-//!    let subscriber = node.subscribe::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
-//!    let publisher = node.create_publisher::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
-//!    let mut timer = node.create_wall_timer(std::time::Duration::from_millis(1000))?;
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let ctx = r2r::Context::create()?;
+//!     let mut node = r2r::Node::create(ctx, "node", "namespace")?;
+//!     let subscriber =
+//!         node.subscribe::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
+//!     let publisher =
+//!         node.create_publisher::<r2r::std_msgs::msg::String>("/topic", QosProfile::default())?;
+//!     let mut timer = node.create_wall_timer(std::time::Duration::from_millis(1000))?;
 //!
-//!    // Set up a simple task executor.
-//!    let mut pool = LocalPool::new();
-//!    let spawner = pool.spawner();
+//!     // Set up a simple task executor.
+//!     let mut pool = LocalPool::new();
+//!     let spawner = pool.spawner();
 //!
-//!    // Run the subscriber in one task, printing the messages
-//!    spawner.spawn_local(async move {
-//!        subscriber.for_each(|msg| {
-//!            println!("got new msg: {}", msg.data);
-//!            future::ready(())
-//!        }).await
-//!    })?;
+//!     // Run the subscriber in one task, printing the messages
+//!     spawner.spawn_local(async move {
+//!         subscriber
+//!             .for_each(|msg| {
+//!                 println!("got new msg: {}", msg.data);
+//!                 future::ready(())
+//!             })
+//!             .await
+//!     })?;
 //!
-//!    // Run the publisher in another task
-//!    spawner.spawn_local(async move {
-//!        let mut counter = 0;
-//!        loop {
-//!            let _elapsed = timer.tick().await.unwrap();
-//!            let msg = r2r::std_msgs::msg::String { data: format!("Hello, world! ({})", counter) };
-//!            publisher.publish(&msg).unwrap();
-//!            counter += 1;
-//!        }
-//!    })?;
+//!     // Run the publisher in another task
+//!     spawner.spawn_local(async move {
+//!         let mut counter = 0;
+//!         loop {
+//!             let _elapsed = timer.tick().await.unwrap();
+//!             let msg = r2r::std_msgs::msg::String {
+//!                 data: format!("Hello, world! ({})", counter),
+//!             };
+//!             publisher.publish(&msg).unwrap();
+//!             counter += 1;
+//!         }
+//!     })?;
 //!
-//!    // Main loop spins ros.
-//!    loop {
-//!        node.spin_once(std::time::Duration::from_millis(100));
-//!        pool.run_until_stalled();
-//!    }
-//!}
+//!     // Main loop spins ros.
+//!     loop {
+//!         node.spin_once(std::time::Duration::from_millis(100));
+//!         pool.run_until_stalled();
+//!     }
+//! }
 //! ```
 
 // otherwise crates using r2r needs to specify the same version of uuid as
@@ -76,12 +79,10 @@ mod error;
 pub use error::{Error, Result};
 
 mod msg_types;
-pub use msg_types::generated_msgs::*;
-pub use msg_types::WrappedActionTypeSupport;
-pub use msg_types::WrappedNativeMsg as NativeMsg;
-pub use msg_types::WrappedNativeMsgUntyped;
-pub use msg_types::WrappedServiceTypeSupport;
-pub use msg_types::WrappedTypesupport;
+pub use msg_types::{
+    generated_msgs::*, WrappedActionTypeSupport, WrappedNativeMsg as NativeMsg,
+    WrappedNativeMsgUntyped, WrappedServiceTypeSupport, WrappedTypesupport,
+};
 
 mod utils;
 pub use utils::*;

--- a/r2r/src/msg_types.rs
+++ b/r2r/src/msg_types.rs
@@ -5,11 +5,13 @@ use r2r_rcl::{
     rosidl_service_type_support_t,
 };
 use serde::{Deserialize, Serialize};
-use std::boxed::Box;
-use std::cell::RefCell;
-use std::convert::TryInto;
-use std::fmt::Debug;
-use std::ops::{Deref, DerefMut};
+use std::{
+    boxed::Box,
+    cell::RefCell,
+    convert::TryInto,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 pub mod generated_msgs {
     #![allow(clippy::all)]
@@ -551,8 +553,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::generated_msgs::*;
-    use super::*;
+    use super::{generated_msgs::*, *};
     use r2r_rcl::*;
 
     #[test]

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1,36 +1,39 @@
-use futures::channel::{mpsc, oneshot};
-use futures::future::FutureExt;
-use futures::future::TryFutureExt;
-use futures::future::{self, join_all};
-use futures::stream::{Stream, StreamExt};
-use std::collections::HashMap;
-use std::ffi::{CStr, CString};
-use std::future::Future;
-use std::marker::PhantomPinned;
-use std::mem::MaybeUninit;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use futures::{
+    channel::{mpsc, oneshot},
+    future::{self, join_all, FutureExt, TryFutureExt},
+    stream::{Stream, StreamExt},
+};
+use std::{
+    collections::HashMap,
+    ffi::{CStr, CString},
+    future::Future,
+    marker::PhantomPinned,
+    mem::MaybeUninit,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use r2r_actions::*;
 use r2r_rcl::*;
 
-use crate::action_clients::*;
-use crate::action_clients_untyped::*;
-use crate::action_servers::*;
-use crate::clients::*;
-use crate::clocks::*;
-use crate::context::*;
-use crate::error::*;
-use crate::msg_types::generated_msgs::rcl_interfaces;
-use crate::msg_types::*;
-use crate::parameters::*;
-use crate::publishers::*;
-use crate::qos::QosProfile;
-use crate::services::*;
-use crate::subscribers::*;
 #[cfg(r2r__rosgraph_msgs__msg__Clock)]
 use crate::time_source::TimeSource;
+use crate::{
+    action_clients::*,
+    action_clients_untyped::*,
+    action_servers::*,
+    clients::*,
+    clocks::*,
+    context::*,
+    error::*,
+    msg_types::{generated_msgs::rcl_interfaces, *},
+    parameters::*,
+    publishers::*,
+    qos::QosProfile,
+    services::*,
+    subscribers::*,
+};
 
 /// A ROS Node.
 ///
@@ -502,8 +505,7 @@ impl Node {
         req: ServiceRequest<rcl_interfaces::srv::DescribeParameters::Service>,
         params: &Arc<Mutex<HashMap<String, Parameter>>>,
     ) -> future::Ready<()> {
-        use rcl_interfaces::msg::ParameterDescriptor;
-        use rcl_interfaces::srv::DescribeParameters;
+        use rcl_interfaces::{msg::ParameterDescriptor, srv::DescribeParameters};
         let mut descriptors = Vec::<ParameterDescriptor>::new();
         let params = params.lock().unwrap();
         for name in &req.message.names {

--- a/r2r/src/publishers.rs
+++ b/r2r/src/publishers.rs
@@ -1,17 +1,12 @@
-use futures::channel::oneshot;
-use futures::Future;
-use futures::TryFutureExt;
-use std::ffi::c_void;
-use std::ffi::CString;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::sync::Mutex;
-use std::sync::Once;
-use std::sync::Weak;
+use futures::{channel::oneshot, Future, TryFutureExt};
+use std::{
+    ffi::{c_void, CString},
+    fmt::Debug,
+    marker::PhantomData,
+    sync::{Mutex, Once, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::*;
-use crate::qos::QosProfile;
+use crate::{error::*, msg_types::*, qos::QosProfile};
 use r2r_rcl::*;
 
 // The publish function is thread safe. ROS2 docs state:

--- a/r2r/src/services.rs
+++ b/r2r/src/services.rs
@@ -1,10 +1,11 @@
 use futures::channel::{mpsc, oneshot};
-use std::ffi::CString;
-use std::mem::MaybeUninit;
-use std::sync::{Arc, Mutex, Weak};
+use std::{
+    ffi::CString,
+    mem::MaybeUninit,
+    sync::{Arc, Mutex, Weak},
+};
 
-use crate::error::*;
-use crate::msg_types::*;
+use crate::{error::*, msg_types::*};
 use r2r_rcl::*;
 
 /// Encapsulates a service request.

--- a/r2r/src/subscribers.rs
+++ b/r2r/src/subscribers.rs
@@ -1,12 +1,9 @@
 use futures::channel::mpsc;
 use std::ffi::CString;
 
-use crate::error::*;
-use crate::msg_types::*;
-use crate::qos::QosProfile;
+use crate::{error::*, msg_types::*, qos::QosProfile};
 use r2r_rcl::*;
-use std::ffi::c_void;
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
 
 pub trait Subscriber_ {
     fn handle(&self) -> &rcl_subscription_t;

--- a/r2r/src/time_source.rs
+++ b/r2r/src/time_source.rs
@@ -1,11 +1,13 @@
 #![cfg(r2r__rosgraph_msgs__msg__Clock)]
 
-use crate::builtin_interfaces::msg::Time;
-use crate::error::*;
-use crate::msg_types::{VoidPtr, WrappedNativeMsg};
-use crate::rosgraph_msgs;
-use crate::subscribers::{create_subscription_helper, Subscriber_};
-use crate::{Clock, ClockType, Node, QosProfile, WrappedTypesupport};
+use crate::{
+    builtin_interfaces::msg::Time,
+    error::*,
+    msg_types::{VoidPtr, WrappedNativeMsg},
+    rosgraph_msgs,
+    subscribers::{create_subscription_helper, Subscriber_},
+    Clock, ClockType, Node, QosProfile, WrappedTypesupport,
+};
 use r2r_rcl::{
     rcl_node_t, rcl_subscription_fini, rcl_subscription_t, rcl_take, rcl_time_point_value_t,
     rmw_message_info_t, RCL_RET_OK,

--- a/r2r/src/utils.rs
+++ b/r2r/src/utils.rs
@@ -1,7 +1,11 @@
 use r2r_rcl::*;
-use std::ffi::CString;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, MutexGuard};
+use std::{
+    ffi::CString,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex, MutexGuard,
+    },
+};
 
 use lazy_static::lazy_static;
 

--- a/r2r/tests/threads.rs
+++ b/r2r/tests/threads.rs
@@ -1,5 +1,4 @@
-use std::thread;
-use std::time::Duration;
+use std::{thread, time::Duration};
 
 use r2r::QosProfile;
 

--- a/r2r/tests/tokio_test_raw.rs
+++ b/r2r/tests/tokio_test_raw.rs
@@ -1,6 +1,5 @@
 use futures::stream::StreamExt;
-use r2r::QosProfile;
-use r2r::WrappedTypesupport;
+use r2r::{QosProfile, WrappedTypesupport};
 use tokio::task;
 
 const N_CONCURRENT_ROS_CONTEXT: usize = 3;

--- a/r2r_actions/build.rs
+++ b/r2r_actions/build.rs
@@ -1,6 +1,8 @@
-use std::fs::OpenOptions;
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::{
+    env, fs,
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+};
 
 const BINDINGS_FILENAME: &str = "action_bindings.rs";
 

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -1,11 +1,13 @@
 use os_str_bytes::RawOsString;
 use regex::*;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::env;
-use std::fs::{self, File};
-use std::io::Read;
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    env,
+    fs::{self, File},
+    io::Read,
+    path::Path,
+};
 
 #[cfg(not(feature = "doc-only"))]
 const SUPPORTED_ROS_DISTROS: &[&str] = &["foxy", "galactic", "humble", "iron", "rolling"];

--- a/r2r_macros/src/lib.rs
+++ b/r2r_macros/src/lib.rs
@@ -1,7 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
-use syn::spanned::Spanned;
-use syn::{parse_macro_input, Data, DeriveInput, Fields};
+use syn::{parse_macro_input, spanned::Spanned, Data, DeriveInput, Fields};
 
 extern crate proc_macro;
 

--- a/r2r_msg_gen/build.rs
+++ b/r2r_msg_gen/build.rs
@@ -1,19 +1,15 @@
 use bindgen::Bindings;
-use itertools::chain;
-use itertools::iproduct;
-use itertools::Either;
-use itertools::Itertools;
-use quote::format_ident;
-use quote::quote;
+use itertools::{chain, iproduct, Either, Itertools};
+use quote::{format_ident, quote};
 use r2r_common::{camel_to_snake, RosMsg};
 use rayon::prelude::*;
-use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::prelude::*;
-use std::io::BufWriter;
-use std::mem;
-use std::path::{Path, PathBuf};
-use std::{env, fs};
+use std::{
+    env, fs,
+    fs::{File, OpenOptions},
+    io::{prelude::*, BufWriter},
+    mem,
+    path::{Path, PathBuf},
+};
 
 const MSG_INCLUDES_FILENAME: &str = "msg_includes.h";
 const INTROSPECTION_FILENAME: &str = "introspection_functions.rs";

--- a/r2r_msg_gen/src/introspection.rs
+++ b/r2r_msg_gen/src/introspection.rs
@@ -1,13 +1,14 @@
-use crate::rosidl_message_type_support_t as CTypeSupport;
-use crate::rosidl_typesupport_introspection_c__MessageMember as CMessageMember;
-use crate::rosidl_typesupport_introspection_c__MessageMembers as CMessageMembers;
-use crate::rust_mangle;
+use crate::{
+    rosidl_message_type_support_t as CTypeSupport,
+    rosidl_typesupport_introspection_c__MessageMember as CMessageMember,
+    rosidl_typesupport_introspection_c__MessageMembers as CMessageMembers, rust_mangle,
+};
 use quote::quote;
-use std::borrow::Cow;
-use std::ffi::c_char;
-use std::ffi::CStr;
-use std::mem;
-use std::slice;
+use std::{
+    borrow::Cow,
+    ffi::{c_char, CStr},
+    mem, slice,
+};
 
 pub struct Introspection<'a> {
     pub module: &'a str,

--- a/r2r_msg_gen/src/lib.rs
+++ b/r2r_msg_gen/src/lib.rs
@@ -23,13 +23,11 @@ use {
     std::mem,
 };
 
-use quote::format_ident;
-use quote::quote;
+use quote::{format_ident, quote};
 use r2r_common::RosMsg;
 use r2r_rcl::*;
 
-use std::borrow::Cow;
-use std::ffi::CStr;
+use std::{borrow::Cow, ffi::CStr};
 
 use std::slice;
 

--- a/r2r_rcl/build.rs
+++ b/r2r_rcl/build.rs
@@ -1,8 +1,8 @@
-use std::env;
-use std::fs;
-use std::fs::OpenOptions;
-use std::path::Path;
-use std::path::PathBuf;
+use std::{
+    env, fs,
+    fs::OpenOptions,
+    path::{Path, PathBuf},
+};
 
 fn main() {
     r2r_common::print_cargo_watches();

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -5,8 +5,7 @@
 #![allow(dead_code)]
 include!(concat!(env!("OUT_DIR"), "/rcl_bindings.rs"));
 
-use std::ffi::CStr;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 
 impl Default for rmw_message_info_t {
     fn default() -> Self {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,9 @@
+edition = "2021"
 hard_tabs = false
 tab_spaces = 4
 reorder_imports = true
 newline_style = "Unix"
 fn_call_width = 80
 fn_params_layout = "Compressed"
+imports_granularity = "Crate"
+format_code_in_doc_comments = true


### PR DESCRIPTION
This PR adds these options to `rustfmt.toml` and executes rustfmt on the source code.

```toml
edition = "2021"
imports_granularity = "Crate" 
format_code_in_doc_comments = true
```