### PR TITLE
Add a `r2r_info` example to print environmental information for r2r

### DIFF
--- a/r2r_common/examples/r2r_info.rs
+++ b/r2r_common/examples/r2r_info.rs
@@ -1,0 +1,44 @@
+//! Prints the environmental information for r2r.
+
+use r2r_common::RosMsg;
+
+fn main() {
+    println!("# r2r Information");
+
+    println!("## Env Hash");
+    println!("{}", r2r_common::get_env_hash());
+    println!();
+
+    println!("## Messages");
+    println!();
+    for msg in r2r_common::get_wanted_messages() {
+        let RosMsg {
+            module,
+            prefix,
+            name,
+        } = msg;
+        println!("- `{module}/{prefix}/{name}`");
+    }
+    println!();
+
+    println!("## Cargo ROS Distro");
+    println!();
+    println!("```");
+    r2r_common::print_cargo_ros_distro();
+    println!("```");
+    println!();
+
+    println!("## Cargo Link Watches");
+    println!();
+    println!("```");
+    r2r_common::print_cargo_watches();
+    println!("```");
+    println!();
+
+    println!("## Cargo Link Search");
+    println!();
+    println!("```");
+    r2r_common::print_cargo_link_search();
+    println!("```");
+    println!();
+}

--- a/r2r_common/src/lib.rs
+++ b/r2r_common/src/lib.rs
@@ -315,7 +315,6 @@ fn get_msgs_from_package(package: &Path) -> Vec<String> {
                                 &l[7..l.len() - 4] // .idl
                             };
                             let action_name = format!("{}/action/{}", file_name_str, substr);
-                            println!("found action: {}", action_name);
                             msgs.push(action_name);
                         }
                     }


### PR DESCRIPTION
This PR adds an `r2r_info` example that prints Markdown-formatted report, which lists the environment hash, cargo prints, etc. It is added for convenience to inspect the ROS environment.