### PR TITLE
Add assertions to rcl wrapper

### DIFF
--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -1239,12 +1239,17 @@ impl Node {
             let types = unsafe { std::slice::from_raw_parts(tnat.types, tnat.names.size) };
 
             for (n, t) in names.iter().zip(types) {
+                assert!(!(*n).is_null());
                 let topic_name = unsafe { CStr::from_ptr(*n).to_str().unwrap().to_owned() };
+                assert!(!t.data.is_null());
                 let topic_types = unsafe { std::slice::from_raw_parts(t, t.size) };
                 let topic_types: Vec<String> = unsafe {
                     topic_types
                         .iter()
-                        .map(|t| CStr::from_ptr(*(t.data)).to_str().unwrap().to_owned())
+                        .map(|t| {
+                            assert!(*(t.data) != std::ptr::null_mut());
+                            CStr::from_ptr(*(t.data)).to_str().unwrap().to_owned()
+                        })
                         .collect()
                 };
                 res.insert(topic_name, topic_types);

--- a/r2r_rcl/src/lib.rs
+++ b/r2r_rcl/src/lib.rs
@@ -116,7 +116,7 @@ macro_rules! primitive_sequence {
                     unsafe { [<$ctype __Sequence__fini>] (self as *mut _); }
                     unsafe { [<$ctype __Sequence__init>] (self as *mut _, values.len()); }
                     if self.data != std::ptr::null_mut() {
-                        unsafe { std::ptr::copy(values.as_ptr(), self.data, values.len()); }
+                        unsafe { std::ptr::copy_nonoverlapping(values.as_ptr(), self.data, values.len()); }
                     }
                 }
 
@@ -126,7 +126,7 @@ macro_rules! primitive_sequence {
                     }
                     let mut target = Vec::with_capacity(self.size);
                     unsafe {
-                        std::ptr::copy(self.data, target.as_mut_ptr(), self.size);
+                        std::ptr::copy_nonoverlapping(self.data, target.as_mut_ptr(), self.size);
                         target.set_len(self.size);
                     }
                     target


### PR DESCRIPTION
This adds a few minor asserts and improvements to the RCL layer. Specifically:

1. It adds a few `null` checks in the graph introspection code. Introspection is not particularly performance-critical, I suspect that it's worthwhile to add these checks rather than risk undefined behaviour
2. It changes the data copies in the vector-copying code from `copy` to `copy_nonoverlapping`. There is no reason not to do it and it might provide a slight speedup.