### PR TITLE
Expose WrongParameterType

### DIFF
--- a/r2r/src/lib.rs
+++ b/r2r/src/lib.rs
@@ -115,7 +115,7 @@ mod context;
 pub use context::Context;
 
 mod parameters;
-pub use parameters::{Parameter, ParameterValue, RosParams};
+pub use parameters::{Parameter, ParameterValue, RosParams, WrongParameterType};
 
 pub use r2r_macros::RosParams;
 


### PR DESCRIPTION
I'm creating a compatibility layer of multiple robotics libraries, and I found that I need to write code like this:

```rust
pub struct NodeHandler<'b>(&'b mut r2r::Node);

pub trait ParamType: Sized
where
    ParameterValue: TryInto<Self, Error = WrongParameterType>,
{
    fn get(node: &mut NodeHandler, key: &str) -> Result<Self> {
        let result = node.0.get_parameter::<Self>(key);
        match result {
            Ok(val) => Ok(val),
            Err(r2r::Error::ParameterWrongType {
                name: _,
                expected_type: _,
                actual_type: "not set",
            }) => Err(crate::Error::ParameterNotFound(key.to_owned())),
            Err(e) => Err(e.into()),
        }
    }
}

impl ParamType for bool {}
impl ParamType for String {}
impl ParamType for i64 {}
impl ParamType for f64 {}

impl ParamType for Vec<bool> {}
impl ParamType for Vec<String> {}
impl ParamType for Vec<i64> {}
impl ParamType for Vec<f64> {}
```

In order to call `get_parameter`, I need to add a trait bound `ParameterValue: TryInto<Self, Error = WrongParameterType>` (the same generic bound for `Node::get_parameter`). So, it is needed to have `WrongParameterType`.