### PR TITLE
Update bindgen 0.63.0 -> 0.71.1 (#116)

### DIFF
--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -15,7 +15,7 @@ r2r_rcl = { path = "../r2r_rcl", version = "0.9.4" }
 r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.4" }
 
 [build-dependencies]
-bindgen = "0.63.0"
+bindgen = "0.71.1"
 r2r_common = { path = "../r2r_common", version = "0.9.4" }
 
 [features]

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-bindgen = "0.63.0"
+bindgen = "0.71.1"
 sha2 = "0.10.6"
 os_str_bytes = "6.5.1"
 regex = "1.8.4"

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -21,7 +21,7 @@ force-send-sync = "1.0.0"
 rayon = "1.7.0"
 
 [build-dependencies]
-bindgen = "0.63.0"
+bindgen = "0.71.1"
 r2r_rcl = { path = "../r2r_rcl", version = "0.9.4" }
 r2r_common = { path = "../r2r_common", version = "0.9.4" }
 quote = "1.0.28"

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -15,7 +15,7 @@ paste = "1.0.9"
 widestring = "1.0.2"
 
 [build-dependencies]
-bindgen = "0.63.0"
+bindgen = "0.71.1"
 r2r_common = { path = "../r2r_common", version = "0.9.4" }
 
 [features]


### PR DESCRIPTION
bindgen `0.63.0` didn't expand/include the following macros on some systems:
```C
// {ROS_BASE}/include/rosidl_runtime_c/rosidl_runtime_c/primitives_sequence_functions.h
...
ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(float)
ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(double)
ROSIDL_RUNTIME_C__DECLARE_PRIMITIVE_SEQUENCE_FUNCTIONS(long_double)
...
```
This change fixes this by now generating the missing primitive sequence functions. 
I have manually tested it to compile and work on Ubuntu 22.04 with ROS2 Humble and Iron using some simple messages.
