### PR TITLE
Initialize rosout publisher on node create

### DIFF
--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -182,7 +182,7 @@ impl Node {
 
     /// Creates a ROS node.
     pub fn create(ctx: Context, name: &str, namespace: &str) -> Result<Node> {
-        let (res, node_handle) = {
+        let (res, mut node_handle) = {
             let mut ctx_handle = ctx.context_handle.lock().unwrap();
 
             let c_node_name = CString::new(name).unwrap();

--- a/r2r/src/nodes.rs
+++ b/r2r/src/nodes.rs
@@ -203,6 +203,8 @@ impl Node {
         };
 
         if res == RCL_RET_OK as i32 {
+            init_rosout_publisher(node_handle.as_mut())?;
+
             let ros_clock = Arc::new(Mutex::new(Clock::create(ClockType::RosTime)?));
             #[cfg(r2r__rosgraph_msgs__msg__Clock)]
             let time_source = {
@@ -1693,9 +1695,31 @@ impl Drop for Node {
 
             p.destroy(self.node_handle.as_mut());
         }
+        fini_rosout_publisher(self.node_handle.as_mut());
         unsafe {
             rcl_node_fini(self.node_handle.as_mut());
         }
+    }
+}
+
+fn init_rosout_publisher(node_handle: &mut rcl_node_t) -> Result<()> {
+    if !unsafe { rcl_logging_rosout_enabled() } {
+        return Ok(());
+    }
+    let options = unsafe { rcl_node_get_options(node_handle) };
+    if options.is_null() || !unsafe { (*options).enable_rosout } {
+        return Ok(());
+    }
+    let ret = unsafe { rcl_logging_rosout_init_publisher_for_node(node_handle) };
+    if ret != RCL_RET_OK as i32 {
+        return Err(Error::from_rcl_error(ret));
+    }
+    Ok(())
+}
+
+fn fini_rosout_publisher(node_handle: &mut rcl_node_t) {
+    if unsafe { rcl_logging_rosout_enabled() } {
+        unsafe { rcl_logging_rosout_fini_publisher_for_node(node_handle) };
     }
 }
 

--- a/r2r_rcl/bindings/rcl_bindings.rs
+++ b/r2r_rcl/bindings/rcl_bindings.rs
@@ -7444,6 +7444,12 @@ extern "C" {
     pub fn rcl_logging_rosout_enabled() -> bool;
 }
 extern "C" {
+    pub fn rcl_logging_rosout_init_publisher_for_node(node: *mut rcl_node_t) -> rcl_ret_t;
+}
+extern "C" {
+    pub fn rcl_logging_rosout_fini_publisher_for_node(node: *mut rcl_node_t) -> rcl_ret_t;
+}
+extern "C" {
     pub fn rcl_logging_multiple_output_handler(
         location: *const rcutils_log_location_t,
         severity: ::std::os::raw::c_int,

--- a/r2r_rcl/src/rcl_wrapper.h
+++ b/r2r_rcl/src/rcl_wrapper.h
@@ -13,6 +13,7 @@
 
 // logging
 #include <rcl/logging.h>
+#include <rcl/logging_rosout.h>
 
 // errors
 #include <rcutils/error_handling.h>


### PR DESCRIPTION
## Summary

- Register a `/rosout` publisher when an r2r `Node` is created, matching rclcpp behavior
- Tear down the rosout publisher in `Node`'s `Drop` implementation before `rcl_node_fini`
- Add FFI bindings for `rcl_logging_rosout_init_publisher_for_node` and `rcl_logging_rosout_fini_publisher_for_node`

## Problem

r2r nodes call `rcl_node_init()` but never call `rcl_logging_rosout_init_publisher_for_node()`. As a result, log messages emitted via `r2r::log_*!` / `rcutils_log()` are written to the console and log files, but are **not published to `/rosout`**. C++ nodes created through rclcpp do not have this issue.

## Solution

After a successful `rcl_node_init()`, initialize the rosout publisher when rosout logging is enabled and `enable_rosout` is true on the node options. On node destruction, call `rcl_logging_rosout_fini_publisher_for_node()` before finalizing the node handle.

This mirrors the logic in rclcpp's `NodeBase` constructor/destructor.

## Test plan

- [x] Build r2r with ROS 2 Jazzy sourced
- [x] Run `cargo run --example logging -- --ros-args -r __node:=r2r_log_test` and confirm messages appear on `/rosout`
- [x] Verify `ros2 node info` lists `/rosout: rcl_interfaces/msg/Log` for the node
- [x] Confirm existing r2r consumers (e.g. application nodes using `node.logger()` with `log_info!`) publish to `/rosout` without additional application changes


Made with [Cursor](https://cursor.com)