### PR TITLE
fix: update bindgen for Clang type definitions

### DIFF
--- a/r2r_actions/Cargo.toml
+++ b/r2r_actions/Cargo.toml
@@ -15,7 +15,8 @@ r2r_rcl = { path = "../r2r_rcl", version = "0.9.6" }
 r2r_msg_gen = { path = "../r2r_msg_gen", version = "0.9.6" }
 
 [build-dependencies]
-bindgen = "0.71.1"
+# Use the release that handles Clang type definitions correctly.
+bindgen = "0.72.1"
 r2r_common = { path = "../r2r_common", version = "0.9.6" }
 
 [features]

--- a/r2r_common/Cargo.toml
+++ b/r2r_common/Cargo.toml
@@ -11,7 +11,8 @@ repository = "https://github.com/sequenceplanner/r2r"
 documentation = "https://docs.rs/r2r/latest/r2r"
 
 [dependencies]
-bindgen = "0.71.1"
+# Use the release that handles Clang type definitions correctly.
+bindgen = "0.72.1"
 sha2 = "0.10.6"
 os_str_bytes = "6.5.1"
 regex = "1.8.4"

--- a/r2r_msg_gen/Cargo.toml
+++ b/r2r_msg_gen/Cargo.toml
@@ -21,7 +21,8 @@ force-send-sync = "1.0.0"
 rayon = "1.7.0"
 
 [build-dependencies]
-bindgen = "0.71.1"
+# Use the release that handles Clang type definitions correctly.
+bindgen = "0.72.1"
 r2r_rcl = { path = "../r2r_rcl", version = "0.9.6" }
 r2r_common = { path = "../r2r_common", version = "0.9.6" }
 quote = "1.0.28"

--- a/r2r_rcl/Cargo.toml
+++ b/r2r_rcl/Cargo.toml
@@ -15,7 +15,8 @@ paste = "1.0.9"
 widestring = "1.0.2"
 
 [build-dependencies]
-bindgen = "0.71.1"
+# Use the release that handles Clang type definitions correctly.
+bindgen = "0.72.1"
 r2r_common = { path = "../r2r_common", version = "0.9.6" }
 
 [features]


### PR DESCRIPTION
Clang's changed handling of type declarations can cause bindgen to emit opaque ROS type-support structs, leaving r2r's message generator unable to access their fields. Update bindgen in all four consumers to the release containing the upstream Clang compatibility fix: https://github.com/rust-lang/rust-bindgen/releases/tag/v0.72.1.

Keeping r2r_common, r2r_rcl, r2r_msg_gen, and r2r_actions on the same bindgen version preserves compatibility of the Builder and Bindings types passed between them.

Validation so far: the equivalent dependency-only change based on r2r 0.9.5 builds the Bit-Bots extrinsic calibration package against ROS Jazzy and libclang 22, without its previous vendored r2r_msg_gen workaround. Generated rosidl_message_type_support_t bindings expose the data field correctly. This PR applies that change to current master; the full upstream test matrix has not been run locally.
